### PR TITLE
QA update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,26 +28,31 @@ matrix:
     - php: '7.0'
     # aliased to a recent 7.1.x version
     - php: '7.1'
+    # bleeding edge
+    - php: 'nightly'
     # aliased to a recent hhvm version
     - php: 'hhvm'
 
   allow_failures:
     - php: 'hhvm'
+    - php: 'nightly'
 
-before_script:
-  - export PHPCS_DIR=/tmp/phpcs
-  - export SNIFFS_DIR=/tmp/sniffs
-  # Install CodeSniffer for WordPress Coding Standards checks.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
-  # Install WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
-  # Install PHP Compatibility sniffs.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
-  # Set install path for PHPCS sniffs.
-  # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
-  # After CodeSniffer install you should refresh your path.
-  - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
+before_install:
+    - export PHPCS_DIR=/tmp/phpcs
+    - export SNIFFS_DIR=/tmp/sniffs
+    # Install CodeSniffer for WordPress Coding Standards checks.
+    # @TODO Change branch back to master once WPCS + PHPCompatibility are compatible with PHPCS 3.x.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b 2.9 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
+    # Install WordPress Coding Standards.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b develop --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+    # Install PHP Compatibility sniffs.
+    # @TODO ADJUST PATH FOR Composer PR when merged!
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
+    # Set install path for PHPCS sniffs.
+    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
+    # After CodeSniffer install you should refresh your path.
+    - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
 
 
 # Run test script commands.
@@ -55,14 +60,11 @@ before_script:
 script:
     # Search for PHP syntax errors.
     - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-    # WordPress Coding Standards.
+    # Check code against the WordPress Coding Standards and for PHP cross-version compatibility.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+    # @link https://github.com/wimg/phpcompatibility
     # @link http://pear.php.net/package/PHP_CodeSniffer/
-    # -p flag: Show progress of the run.
-    # -s flag: Show sniff codes in all reports.
-    # -v flag: Print verbose output.
-    # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
-    # --standard: Use WordPress as the standard.
-    # --extensions: Only sniff PHP files.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -n . --standard=./phpcs.xml --extensions=php; fi
+    # Uses a custom ruleset based on WordPress.
+    # Only fails the build on errors, not warnings, but still show warnings in the output.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --standard=./phpcs.xml --runtime-set ignore_warnings_on_exit 1; fi
 

--- a/class-debug-bar-list-php-classes.php
+++ b/class-debug-bar-list-php-classes.php
@@ -124,155 +124,155 @@ if ( ! class_exists( 'Debug_Bar_List_PHP_Classes' ) ) {
 
 			/* == Database Extensions == */
 
-				/* = Abstraction Layers = */
-				// PDO.
-				// @see http://php.net/book.pdo
-				'PDO',
-				'PDOStatement',
-				'PDOException',
-				'PDORow',  // Not in PHP docs.
+			/* = Abstraction Layers = */
+			// PDO.
+			// @see http://php.net/book.pdo
+			'PDO',
+			'PDOStatement',
+			'PDOException',
+			'PDORow',  // Not in PHP docs.
 
 
-				/* = Vendor Specific Database Extensions = */
-				// Mongo.
-				// @see http://php.net/book.mongo
-					// Mongo Core Classes.
-					'MongoClient',
-					'MongoDB',
-					'MongoCollection',
-					'MongoCursor',
-					'MongoCursorInterface',
-					'MongoCommandCursor',
+			/* = Vendor Specific Database Extensions = */
+			// Mongo.
+			// @see http://php.net/book.mongo
+			// Mongo Core Classes.
+			'MongoClient',
+			'MongoDB',
+			'MongoCollection',
+			'MongoCursor',
+			'MongoCursorInterface',
+			'MongoCommandCursor',
 
-					// Mongo Types.
-					'MongoId',
-					'MongoCode',
-					'MongoDate',
-					'MongoRegex',
-					'MongoBinData',
-					'MongoInt32',
-					'MongoInt64',
-					'MongoDBRef',
-					'MongoMinKey',
-					'MongoMaxKey',
-					'MongoTimestamp',
+			// Mongo Types.
+			'MongoId',
+			'MongoCode',
+			'MongoDate',
+			'MongoRegex',
+			'MongoBinData',
+			'MongoInt32',
+			'MongoInt64',
+			'MongoDBRef',
+			'MongoMinKey',
+			'MongoMaxKey',
+			'MongoTimestamp',
 
-					// Mongo GridFS Classes.
-					'MongoGridFS',
-					'MongoGridFSFile',
-					'MongoGridFSCursor',
+			// Mongo GridFS Classes.
+			'MongoGridFS',
+			'MongoGridFSFile',
+			'MongoGridFSCursor',
 
-					// Mongo Batch Classes.
-					'MongoWriteBatch',
-					'MongoInsertBatch',
-					'MongoUpdateBatch',
-					'MongoDeleteBatch',
+			// Mongo Batch Classes.
+			'MongoWriteBatch',
+			'MongoInsertBatch',
+			'MongoUpdateBatch',
+			'MongoDeleteBatch',
 
-					// Mongo Miscellaneous.
-					'MongoLog',
-					'MongoPool',
-					'Mongo',
+			// Mongo Miscellaneous.
+			'MongoLog',
+			'MongoPool',
+			'Mongo',
 
-					// Mongo Exceptions.
-					'MongoException',
-					'MongoResultException',
-					'MongoCursorException',
-					'MongoCursorTimeoutException',
-					'MongoConnectionException',
-					'MongoGridFSException',
-					'MongoDuplicateKeyException',
-					'MongoProtocolException',
-					'MongoExecutionTimeoutException',
-					'MongoWriteConcernException',
+			// Mongo Exceptions.
+			'MongoException',
+			'MongoResultException',
+			'MongoCursorException',
+			'MongoCursorTimeoutException',
+			'MongoConnectionException',
+			'MongoGridFSException',
+			'MongoDuplicateKeyException',
+			'MongoProtocolException',
+			'MongoExecutionTimeoutException',
+			'MongoWriteConcernException',
 
-				// PHP driver for MongoDB.
-				// @see http://php.net/set.mongodb
-					// MongoDB\Driver.
-					'MongoDB\Driver\Manager',
-					'MongoDB\Driver\Command',
-					'MongoDB\Driver\Query',
-					'MongoDB\Driver\BulkWrite',
-					'MongoDB\Driver\WriteConcern',
-					'MongoDB\Driver\ReadPreference',
-					'MongoDB\Driver\Cursor',
-					'MongoDB\Driver\CursorId',
-					'MongoDB\Driver\Server',
-					'MongoDB\Driver\WriteConcernError',
-					'MongoDB\Driver\WriteError',
-					'MongoDB\Driver\WriteResult',
+			// PHP driver for MongoDB.
+			// @see http://php.net/set.mongodb
+			// MongoDB\Driver.
+			'MongoDB\Driver\Manager',
+			'MongoDB\Driver\Command',
+			'MongoDB\Driver\Query',
+			'MongoDB\Driver\BulkWrite',
+			'MongoDB\Driver\WriteConcern',
+			'MongoDB\Driver\ReadPreference',
+			'MongoDB\Driver\Cursor',
+			'MongoDB\Driver\CursorId',
+			'MongoDB\Driver\Server',
+			'MongoDB\Driver\WriteConcernError',
+			'MongoDB\Driver\WriteError',
+			'MongoDB\Driver\WriteResult',
 
-					// BSON.
-					'MongoDB\BSON\Binary',
-					'MongoDB\BSON\Javascript',
-					'MongoDB\BSON\MaxKey',
-					'MongoDB\BSON\MinKey',
-					'MongoDB\BSON\ObjectID',
-					'MongoDB\BSON\Regex',
-					'MongoDB\BSON\Timestamp',
-					'MongoDB\BSON\UTCDatetime',
-					'MongoDB\BSON\Type',
-					'MongoDB\BSON\Persistable',
-					'MongoDB\BSON\Serializable',
-					'MongoDB\BSON\Unserializable',
+			// BSON.
+			'MongoDB\BSON\Binary',
+			'MongoDB\BSON\Javascript',
+			'MongoDB\BSON\MaxKey',
+			'MongoDB\BSON\MinKey',
+			'MongoDB\BSON\ObjectID',
+			'MongoDB\BSON\Regex',
+			'MongoDB\BSON\Timestamp',
+			'MongoDB\BSON\UTCDatetime',
+			'MongoDB\BSON\Type',
+			'MongoDB\BSON\Persistable',
+			'MongoDB\BSON\Serializable',
+			'MongoDB\BSON\Unserializable',
 
-					// MongoDB Exceptions.
-					'MongoDB\Driver\Exception\AuthenticationException',
-					'MongoDB\Driver\Exception\BulkWriteException',
-					'MongoDB\Driver\Exception\ConnectionException',
-					'MongoDB\Driver\Exception\ConnectionTimeoutException',
-					'MongoDB\Driver\Exception\Exception',
-					'MongoDB\Driver\Exception\ExecutionTimeoutException',  // (No version information available, might only be in Git).
-					'MongoDB\Driver\Exception\InvalidArgumentException',
-					'MongoDB\Driver\Exception\LogicException',
-					'MongoDB\Driver\Exception\RuntimeException',
-					'MongoDB\Driver\Exception\SSLConnectionException',
-					'MongoDB\Driver\Exception\UnexpectedValueException',
-					'MongoDB\Driver\Exception\WriteException',
+			// MongoDB Exceptions.
+			'MongoDB\Driver\Exception\AuthenticationException',
+			'MongoDB\Driver\Exception\BulkWriteException',
+			'MongoDB\Driver\Exception\ConnectionException',
+			'MongoDB\Driver\Exception\ConnectionTimeoutException',
+			'MongoDB\Driver\Exception\Exception',
+			'MongoDB\Driver\Exception\ExecutionTimeoutException',  // (No version information available, might only be in Git).
+			'MongoDB\Driver\Exception\InvalidArgumentException',
+			'MongoDB\Driver\Exception\LogicException',
+			'MongoDB\Driver\Exception\RuntimeException',
+			'MongoDB\Driver\Exception\SSLConnectionException',
+			'MongoDB\Driver\Exception\UnexpectedValueException',
+			'MongoDB\Driver\Exception\WriteException',
 
-					'MongoDB\Driver\DuplicateKeyException', // No longer in the manual, possibly deprecated ?
-					'MongoDB\Driver\WriteConcernException', // No longer in the manual, possibly deprecated ?
+			'MongoDB\Driver\DuplicateKeyException', // No longer in the manual, possibly deprecated ?
+			'MongoDB\Driver\WriteConcernException', // No longer in the manual, possibly deprecated ?
 
-				// MySQL.
-				// @see http://php.net/set.mysqlinfo
-					// Mysqli - MySQL Improved Extension.
-					// @see http://php.net/book.mysqli
-					'mysqli',
-					'mysqli_stmt',
-					'mysqli_result',
-					'mysqli_driver',
-					'mysqli_warning',
-					'mysqli_sql_exception',
+			// MySQL.
+			// @see http://php.net/set.mysqlinfo
+			// Mysqli - MySQL Improved Extension.
+			// @see http://php.net/book.mysqli
+			'mysqli',
+			'mysqli_stmt',
+			'mysqli_result',
+			'mysqli_driver',
+			'mysqli_warning',
+			'mysqli_sql_exception',
 
-					// Mysqlnd_uh - Mysqlnd user handler plugin.
-					// @see http://php.net/book.mysqlnd-uh
-					'MysqlndUhConnection',
-					'MysqlndUhPreparedStatement',
+			// Mysqlnd_uh - Mysqlnd user handler plugin.
+			// @see http://php.net/book.mysqlnd-uh
+			'MysqlndUhConnection',
+			'MysqlndUhPreparedStatement',
 
-				// OCI8 - Oracle OCI8.
-				// @see http://php.net/book.oci8
-				'OCI-Collection',
-				'OCI-Lob',
+			// OCI8 - Oracle OCI8.
+			// @see http://php.net/book.oci8
+			'OCI-Collection',
+			'OCI-Lob',
 
-				// SQLLite.
-				// @see http://php.net/ref.sqlite
-				'SQLiteDatabase',  // Not easy to find in PHP docs.
-				'SQLiteResult',  // Not easy to find in PHP docs.
-				'SQLiteUnbuffered',  // Not easy to find in PHP docs.
-				'SQLiteException',	// Not easy to find in PHP docs.
+			// SQLLite.
+			// @see http://php.net/ref.sqlite
+			'SQLiteDatabase',   // Not easy to find in PHP docs.
+			'SQLiteResult',     // Not easy to find in PHP docs.
+			'SQLiteUnbuffered', // Not easy to find in PHP docs.
+			'SQLiteException',  // Not easy to find in PHP docs.
 
-				// SQLite3.
-				// @see http://php.net/book.sqlite3
-				'SQLite3',
-				'SQLite3Stmt',
-				'SQLite3Result',
+			// SQLite3.
+			// @see http://php.net/book.sqlite3
+			'SQLite3',
+			'SQLite3Stmt',
+			'SQLite3Result',
 
-				// Tokyo_tyrant.
-				// @see http://php.net/book.tokyo-tyrant
-				'TokyoTyrant',
-				'TokyoTyrantTable',
-				'TokyoTyrantQuery',
-				'TokyoTyrantIterator',
-				'TokyoTyrantException',
+			// Tokyo_tyrant.
+			// @see http://php.net/book.tokyo-tyrant
+			'TokyoTyrant',
+			'TokyoTyrantTable',
+			'TokyoTyrantQuery',
+			'TokyoTyrantIterator',
+			'TokyoTyrantException',
 
 
 			/* == Date and Time Related Extensions == */
@@ -494,75 +494,75 @@ if ( ! class_exists( 'Debug_Bar_List_PHP_Classes' ) ) {
 
 			// SPL - Standard PHP Library (SPL).
 			// @see http://php.net/book.spl
-				// SPL Data structures.
-				'SplDoublyLinkedList',
-				'SplStack',
-				'SplQueue',
-				'SplHeap',
-				'SplMaxHeap',
-				'SplMinHeap',
-				'SplPriorityQueue',
-				'SplFixedArray',
-				'SplObjectStorage',
+			// SPL Data structures.
+			'SplDoublyLinkedList',
+			'SplStack',
+			'SplQueue',
+			'SplHeap',
+			'SplMaxHeap',
+			'SplMinHeap',
+			'SplPriorityQueue',
+			'SplFixedArray',
+			'SplObjectStorage',
 
-				// SPL Iterators.
-				'AppendIterator',
-				'ArrayIterator',
-				'CachingIterator',
-				'CallbackFilterIterator',
-				'DirectoryIterator',
-				'EmptyIterator',
-				'FilesystemIterator',
-				'FilterIterator',
-				'GlobIterator',
-				'InfiniteIterator',
-				'IteratorIterator',
-				'LimitIterator',
-				'MultipleIterator',
-				'NoRewindIterator',
-				'ParentIterator',
-				'RecursiveArrayIterator',
-				'RecursiveCachingIterator',
-				'RecursiveCallbackFilterIterator',
-				'RecursiveDirectoryIterator',
-				'RecursiveFilterIterator',
-				'RecursiveIteratorIterator',
-				'RecursiveRegexIterator',
-				'RecursiveTreeIterator',
-				'RegexIterator',
+			// SPL Iterators.
+			'AppendIterator',
+			'ArrayIterator',
+			'CachingIterator',
+			'CallbackFilterIterator',
+			'DirectoryIterator',
+			'EmptyIterator',
+			'FilesystemIterator',
+			'FilterIterator',
+			'GlobIterator',
+			'InfiniteIterator',
+			'IteratorIterator',
+			'LimitIterator',
+			'MultipleIterator',
+			'NoRewindIterator',
+			'ParentIterator',
+			'RecursiveArrayIterator',
+			'RecursiveCachingIterator',
+			'RecursiveCallbackFilterIterator',
+			'RecursiveDirectoryIterator',
+			'RecursiveFilterIterator',
+			'RecursiveIteratorIterator',
+			'RecursiveRegexIterator',
+			'RecursiveTreeIterator',
+			'RegexIterator',
 
-				'CachingRecursiveIterator', // Not in PHP docs - deprecated.
+			'CachingRecursiveIterator', // Not in PHP docs - deprecated.
 
-				// SPL Interfaces.
-				'Countable',
-				'OuterIterator',
-				'RecursiveIterator',
-				'SeekableIterator',
+			// SPL Interfaces.
+			'Countable',
+			'OuterIterator',
+			'RecursiveIterator',
+			'SeekableIterator',
 
-				// SPL Exceptions.
-				'BadFunctionCallException',
-				'BadMethodCallException',
-				'DomainException',
-				'InvalidArgumentException',
-				'LengthException',
-				'LogicException',
-				'OutOfBoundsException',
-				'OutOfRangeException',
-				'OverflowException',
-				'RangeException',
-				'RuntimeException',
-				'UnderflowException',
-				'UnexpectedValueException',
+			// SPL Exceptions.
+			'BadFunctionCallException',
+			'BadMethodCallException',
+			'DomainException',
+			'InvalidArgumentException',
+			'LengthException',
+			'LogicException',
+			'OutOfBoundsException',
+			'OutOfRangeException',
+			'OverflowException',
+			'RangeException',
+			'RuntimeException',
+			'UnderflowException',
+			'UnexpectedValueException',
 
-				// SPL File Handling.
-				'SplFileInfo',
-				'SplFileObject',
-				'SplTempFileObject',
+			// SPL File Handling.
+			'SplFileInfo',
+			'SplFileObject',
+			'SplTempFileObject',
 
-				// SPL Miscellaneous Classes and Interfaces.
-				'ArrayObject',
-				'SplObserver',
-				'SplSubject',
+			// SPL Miscellaneous Classes and Interfaces.
+			'ArrayObject',
+			'SplObserver',
+			'SplSubject',
 
 			// SPL Types - SPL Type Handling.
 			// @see http://php.net/book.spl-types

--- a/class-debug-bar-pretty-output.php
+++ b/class-debug-bar-pretty-output.php
@@ -99,6 +99,7 @@ if ( ! class_exists( 'Debug_Bar_Pretty_Output' ) && class_exists( 'Debug_Bar_Pan
 				if ( ! empty( $var ) ) {
 					$output .= 'Array: <br />' . $space . '(<br />';
 					if ( is_int( self::$limit_recursion ) && $depth > self::$limit_recursion ) {
+						/* translators: %d = number used as a limit. */
 						$output .= '... ( ' . sprintf( __( 'output limited at recursion depth %d', 'db-pretty-output' ), self::$limit_recursion ) . ')<br />';
 
 					} else {
@@ -162,6 +163,7 @@ if ( ! class_exists( 'Debug_Bar_Pretty_Output' ) && class_exists( 'Debug_Bar_Pan
 			} elseif ( is_object( $var ) ) {
 				$output .= 'Object: <br />' . $space . '(<br />';
 				if ( is_int( self::$limit_recursion ) && $depth > self::$limit_recursion ) {
+					/* translators: %d = number used as a limit. */
 					$output .= '... ( ' . sprintf( __( 'output limited at recursion depth %d', 'db-pretty-output' ), self::$limit_recursion ) . ')<br />';
 				} else {
 					if ( true !== $short ) {
@@ -653,10 +655,10 @@ if ( ! class_exists( 'Debug_Bar_Pretty_Output' ) && class_exists( 'Debug_Bar_Pan
 		 *
 		 * @deprecated since v1.3 in favour of get_table().
 		 *
-		 * @param array        $array  	   Array to be shown in the table.
-		 * @param string       $col1   	   Label for the first table column.
+		 * @param array        $array      Array to be shown in the table.
+		 * @param string       $col1       Label for the first table column.
 		 * @param string       $col2       Label for the second table column.
-		 * @param string|array $class  	   One or more CSS classes to add to the table.
+		 * @param string|array $class      One or more CSS classes to add to the table.
 		 * @param string       $deprecated ==Deprecated argument.
 		 *
 		 * @return void

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -19,16 +19,47 @@
 	<rule ref="WordPress" />
 
 
+	<!-- ##### Customizations #####-->
+
 	<!-- Add `PHP_Classes` to the whitelist for non-snakecase variable names. -->
 	<rule ref="WordPress.NamingConventions.ValidVariableName">
 	    <properties>
-	        <property name="customVariablesWhitelist" value="PHP_classes" type="array" />
+	        <property name="customPropertiesWhitelist" value="PHP_classes" type="array" />
 	    </properties>
-
-		<!-- TEMPORARY! Exclude a file until WPCS/PR #671 has been merged. -->
-		<exclude-pattern>class-debug-bar-list-php-classes.php</exclude-pattern>
 	</rule>
 
+	<!-- Verify that the text_domain is set to the desired text-domain.
+		 Multiple valid text domains can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="db-pretty-output" />
+		</properties>
+	</rule>
+
+	<!-- Verify that everything in the global namespace is prefixed with a theme specific prefix.
+		 Multiple valid prefixes can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="Debug_Bar,db_pretty_output" />
+		</properties>
+	</rule>
+
+	<!-- Verify that no WP functions are used which are deprecated or have been removed.
+		 The minimum version set here should be in line with the minimum WP version
+		 supported by the Debug Bar extension. -->
+	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<properties>
+			<property name="minimum_supported_version" value="3.4" />
+		</properties>
+	</rule>
+	<rule ref="WordPress.WP.DeprecatedClasses">
+		<properties>
+			<property name="minimum_supported_version" value="3.4" />
+		</properties>
+	</rule>
+
+
+	<!-- ##### Exlusions #####-->
 
 	<!-- Exclude the PHP Core classes list from some documentation checks. -->
 	<rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,14 @@
 <ruleset name="Debug Bar Pretty Output">
 	<description>The code standard for Debug Bar Pretty Output is WordPress.</description>
 
+	<!-- Show progress & sniff codes. -->
+	<arg value="ps"/>
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Check all files in this directory and the directories below it. -->
+	<file>.</file>
+
 	<!-- ##### PHP cross-version compatibility ##### -->
 	<config name="testVersion" value="5.2-99.0"/>
 	<rule ref="PHPCompatibility"/>


### PR DESCRIPTION
### Update Travis build script

* Include PHP nightly in the build matrix.
* Use `before_install` rather than `before_script` to better distinguish between failed install or failed build.
* Use the PHPCS `2.9` branch until the external standards are compatible with PHPCS 3.x.
* Move the standard PHPCS command line arguments to the custom ruleset.
* Show PHPCS warnings, but don't fail the build on it.

### Update the PHPCS ruleset for WPCS 0.12.0

* Update renamed custom property name.
* Remove temporary exclusion.
* Verify that the correct text domain is being used.
* Verify that everything in the global namespace is prefixed correctly.
* Verify that no WP deprecated functions or classes are used.

### Minor codestyle fixes